### PR TITLE
Python3 compatibility

### DIFF
--- a/lib/evasion/common/net.py
+++ b/lib/evasion/common/net.py
@@ -25,8 +25,14 @@ import socket
 import urllib
 import random
 import logging
-import httplib
-import urlparse
+try:
+    # Python2
+    import httplib
+    import urlparse
+except ImportError:
+    # Python3
+    import http.client
+    from urllib.parse import urlparse
 
 
 def get_log():


### PR DESCRIPTION
Add a alternative import path for python3 as it no longer provides httplib and urlparse. This modules where moved.